### PR TITLE
Add eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,20 +26,20 @@ module.exports = {
         requireLast: false,
       },
     }],
-    "capitalized-comments": [
-      "error",
-      "always",
+    'capitalized-comments': [
+      'error',
+      'always',
       {
-          "ignorePattern": "pragma|ignored",
-          "ignoreInlineComments": true
+          'ignorePattern': 'pragma|ignored',
+          'ignoreInlineComments': true,
       },
     ],
     semi: [
-      "error",
-      "always",
+      'error',
+      'always',
     ],
     'no-console': [
-      "error",
+      'error',
       {
         allow: [
           'warn',
@@ -47,5 +47,19 @@ module.exports = {
         ],
       },
     ],
-  }
+    'indent': [
+      'error',
+      2,
+    ],
+    'no-debugger': 'error',
+    'no-unreachable': 'error',
+    'consistent-return': 'error',
+    camelcase: 'error',
+    curly: 'error',
+    eqeqeq: 'error',
+    'multiline-comment-style': [
+      'error',
+      'starred-block',
+    ],
+  },
 };

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -10,7 +10,7 @@ export const getCurrency = createSender('contextCurrency', {});
 /**
  * Get the current content language
  */
- export type contextLanguage = {
+export type contextLanguage = {
   responseType: {
     systemLanguageId: string,
     languageId: string,

--- a/src/ui/componentSection/index.ts
+++ b/src/ui/componentSection/index.ts
@@ -8,7 +8,7 @@ export const add = createSender('uiComponentSectionRenderer', {
 /**
  * Contains all possible components for the sections
  */
- export type uiComponentSectionRenderer =
+export type uiComponentSectionRenderer =
  {
    responseType: void,
    component: string,


### PR DESCRIPTION
Added eslint rules to:

- prevent debugger statements
- prevent unreachable code
- use consistent returns
- have defined multiline comment look and feel
- enforce camelCase usage
- enforce the use of curly braces
- enforce the usage of strict comparison === or !==

Additionally saved the following expression into a const `corsRestriction ? document.referrer : window.parent.origin` in `channel.ts@140`.