### PR TITLE
Draft: NEXT-22761 - Implement admin translation via App

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import * as mainModule from './ui/mainModule';
 import * as module from './ui/module';
 import * as modal from './ui/modal';
 import * as actionButton from './ui/actionButton';
+import * as snippet from './ui/snippet';
 import * as webhook from './app/action';
 import * as data from './data';
 
@@ -27,6 +28,7 @@ const ui = {
   module,
   modal,
   actionButton,
+  snippet,
 };
 
 /**

--- a/src/messages.types.ts
+++ b/src/messages.types.ts
@@ -5,6 +5,7 @@ import type { uiComponentSectionRenderer } from './ui/componentSection/index';
 import type { uiTabsAddTabItem } from './ui/tabs';
 import type { uiModulePaymentOverviewCard } from './ui/module/payment/overviewCard';
 import type { cmsRegisterElement } from './ui/cms';
+import type { extendSnippetFile } from './ui/snippet';
 import type { locationUpdateHeight } from './location/index';
 import type { menuItemAdd } from './ui/menu';
 import type { settingsItemAdd } from './ui/settings';
@@ -48,6 +49,7 @@ export type ShopwareMessageTypes = {
   uiTabsAddTabItem: uiTabsAddTabItem,
   uiModulePaymentOverviewCard: uiModulePaymentOverviewCard,
   cmsRegisterElement: cmsRegisterElement,
+  extendSnippetFile: extendSnippetFile,
   locationUpdateHeight: locationUpdateHeight,
   menuItemAdd: menuItemAdd,
   settingsItemAdd: settingsItemAdd,

--- a/src/ui/snippet/index.ts
+++ b/src/ui/snippet/index.ts
@@ -1,0 +1,25 @@
+import { createSender } from '../../channel';
+
+export const extendFile = createSender('extendSnippetFile');
+
+export type Snippets = {
+  [key: string]: string|Snippets,
+};
+
+export type extendSnippetFile = {
+  responseType: void,
+
+  /**
+   * Locale string of the language to be extended
+   *
+   * @example en-GB
+   */
+  locale: string,
+
+  /**
+   * Snippet json, which extends the translations of the aforementioned locale
+   *
+   * @url https://developer.shopware.com/docs/guides/plugins/plugins/administration/adding-snippets
+   */
+  snippets: Snippets,
+};


### PR DESCRIPTION
Currently, it is not possible to extend snippets via JSON in the Admin via App. With this ticket, the handling via AdminExtensionSDK will be implemented. Without this, for example the blog feature via Custom Entities can’t be translated via LanguagePack.

**Acceptance Criteria**
- Snippets can be imported via AdminExtensionSDK
- Snippets will be validated to not override existing snippets
- Snippets will be sanitized to avoid script injection