### PR TITLE
NEXT-23096 - fix ts declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.2] - 05.01.2023
+
+### Bugfix
+
+- Added two placeholder entities to the global `EntitySchema.Entities` types.
+  This avoids the automatic conversion of an empty interface to the type `never`
+
 ## [3.0.1] - 29.12.2022
 
 ### Changed

--- a/docs/docs/guide/1_getting-started/installation.md
+++ b/docs/docs/guide/1_getting-started/installation.md
@@ -93,15 +93,26 @@ sw.notification.dispatch({
 ## Adding types for Entities (TS only)
 
 The data management inside the SDK supports complete TypeScript support. This allows complete type safety when getting
-entities, editing or saving them. Currently, you need to write the types yourself. But we are working on an auto-generated
-type definitions for the Shopware releases.
+entities, editing or saving them.
 
 For adding the types you need to create a global type definition file like `global.d.ts`. Inside this file you can
 add the types for the entities by extending the global namespace.
 
 ### Using auto-generated types from Shopware
+This is the easiest solution. Just install the correct type definition for the matching shopware version:
 
-This is currently not finished yet and will be released soon.
+`npm install @shopware-ag/entity-schema-types@5.0.0`
+
+The version number should match the Shopware version number without the `6.` in the beginning. Examples:  
+
+`Shopware 6.5.0.0` → `@shopware-ag/entity-schema-types@5.0.0`
+`Shopware 6.5.1.2` → `@shopware-ag/entity-schema-types@5.1.2`
+`Shopware 6.6.3.1` → `@shopware-ag/entity-schema-types@6.3.1`
+
+```ts
+// global.d.ts
+import '@shopware-ag/entity-schema-types';
+```
 
 ### Using "any" fallback
 
@@ -111,7 +122,7 @@ This is the easiest solution. You set the type to `any` for every entity. The do
 // global.d.ts
 declare namespace EntitySchema {
     interface Entities {
-        [entityName: key]: any;
+        [entityName: string]: any;
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-ag/admin-extension-sdk",
   "license": "MIT",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": "git://github.com/shopware/admin-extension-sdk.git",
   "description": "The SDK for App iframes to communicate with the Shopware Administration",
   "keywords": [

--- a/src/_internals/serializer/entity-collection-serializer.ts
+++ b/src/_internals/serializer/entity-collection-serializer.ts
@@ -25,7 +25,6 @@ const EntityCollectionSerializerFactory: SerializerFactory = () => ({
     if (hasType('__EntityCollection__', value)) {
       return new EntityCollection(
         value.__source__,
-        // @ts-expect-error - we know that this property exists in the deserialized object. If not, it will fail
         value.__entityName__,
         value.__context__,
         customizerMethod(value.__criteria__),

--- a/src/_internals/serializer/entity-serializer.ts
+++ b/src/_internals/serializer/entity-serializer.ts
@@ -26,7 +26,6 @@ const EntitySerializerFactory: SerializerFactory = () => ({
     if (hasType('__Entity__', value) && typeof value.__origin__ === 'object') {
       return new EntityClass(
         value.__id__,
-        // @ts-expect-error - we know that this property exists in the deserialized object. If not, it will fail
         value.__entityName__,
         customizerMethod(value.__draft__),
         {

--- a/src/data/_internals/Entity.ts
+++ b/src/data/_internals/Entity.ts
@@ -48,9 +48,11 @@ class EntityClass<EntityName extends keyof Entities> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const that = this;
 
+    // @ts-expect-error - the proxy contains the draft and the entity class
     return new Proxy(this._draft, {
       get(_, property): unknown {
         if (property in that._draft) {
+          // @ts-expect-error - the proxy contains the draft and the entity class
           return that._draft[property];
         }
 

--- a/src/data/_internals/EntityCollection.ts
+++ b/src/data/_internals/EntityCollection.ts
@@ -111,7 +111,6 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
      * Returns true if the entity removed, false if the entity wasn't found
      */
     this.remove = function removeEntityFromCollection(id): boolean {
-      // @ts-expect-error - we know that every entity has an id
       const itemIndex = this.findIndex(i => i.id === id);
 
       if (itemIndex < 0) {
@@ -126,7 +125,6 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
      * Checks if the provided id is inside the collection
      */
     this.has = function hasEntityInCollection(id: string): boolean {
-      // @ts-expect-error - we know that every entity has an id
       return this.some(i => i.id === id);
     };
 
@@ -134,7 +132,6 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
      * Returns the entity for the provided id, null if the entity is not inside the collection
      */
     this.get = function getEntityByIdOfCollection(id: string): Entity<EntityName>|null {
-      // @ts-expect-error - we know that every entity has an id
       const item = this.find(i => i.id === id);
 
       if (typeof item !== 'undefined') {
@@ -161,7 +158,6 @@ export default class EntityCollection<EntityName extends keyof Entities> extends
      * Returns all ids of the internal entities
      */
     this.getIds = function getEntityIdsOfCollection(): string[] {
-      // @ts-expect-error - we know that every entity has an id
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return this.map(i => i.id);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,16 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface Entities {
       /* This will be extended by the entity-schema */
+      private_example_entity: private_example_entity,
+      private_example_entity_two: private_example_entity_two,
+    }
+
+    interface private_example_entity {
+      id: string,
+    }
+
+    interface private_example_entity_two {
+      id: string,
     }
   }
 }

--- a/src/messages.types.ts
+++ b/src/messages.types.ts
@@ -57,21 +57,13 @@ export interface ShopwareMessageTypes {
   actionButtonAdd: actionButtonAdd,
   actionExecute: actionExecute,
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositoryGet: repositoryGet<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositorySearch: repositorySearch<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositorySave: repositorySave<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositoryClone: repositoryClone<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositoryHasChanges: repositoryHasChanges<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositorySaveAll: repositorySaveAll<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositoryDelete: repositoryDelete<any>,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   repositoryCreate: repositoryCreate<any>,
   /* eslint-enable @typescript-eslint/no-explicit-any */
   datasetRegistration: datasetRegistration,
@@ -129,12 +121,10 @@ export type _criteriaTest = {
 export type _collectionTest = {
   responseType: {
     title: string,
-    // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     collection: EntityCollection<any>,
   },
   title: string,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   collection: EntityCollection<any>,
 }
@@ -142,12 +132,10 @@ export type _collectionTest = {
 export type _entityTest = {
   responseType: {
     title: string,
-    // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entity: Entity<any>,
   },
   title: string,
-  // @ts-expect-error - we need any as placeholder. Type values will be set by the direct functions
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   entity: Entity<any>,
 }


### PR DESCRIPTION
The assigning of Entity types does not work like described in the installation documentation. The reason for this was an unwanted conversion of an empty interface to the never type.

With two placeholder entities it don't get converted anymore.

Before:

<img width="1845" alt="Bildschirmfoto 2023-01-05 um 14 22 37" src="https://user-images.githubusercontent.com/14929254/210789934-0cfa9301-b371-419e-b0cf-318ee4bcd7de.png">

After:

<img width="1877" alt="Bildschirmfoto 2023-01-05 um 14 23 37" src="https://user-images.githubusercontent.com/14929254/210790070-21f15382-58ad-40cc-a144-8c617dc668fb.png">
