### PR TITLE
Add `contentPadding` to add/remove card content padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [3.0.4] - 21.03.2023
+
+### Changed
+
+- Added `contentPadding` prop to component section to provide the ability add/remove the card content padding.
+
 ## [3.0.3] - 25.01.2023
 - Added the method `location.get` for getting the actual location ID inside the app
 

--- a/docs/docs/guide/4_concepts/component-sections.md
+++ b/docs/docs/guide/4_concepts/component-sections.md
@@ -17,7 +17,9 @@ if (location.is(location.MAIN_HIDDEN)) {
           title: 'Hello from plugin',
           subtitle: 'I am before the properties card',
           // Some components can render a custom view. In this case the extension can render custom content in the card.
-          locationId: 'my-app-card-before-properties'
+          locationId: 'my-app-card-before-properties',
+          // Add/remove padding of the card content
+          contentPadding: true,
       }
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-ag/admin-extension-sdk",
   "license": "MIT",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "repository": "git://github.com/shopware/admin-extension-sdk.git",
   "description": "The SDK for App iframes to communicate with the Shopware Administration",
   "keywords": [

--- a/src/ui/componentSection/index.ts
+++ b/src/ui/componentSection/index.ts
@@ -29,5 +29,6 @@ interface cardComponentRender {
     title?: string,
     subtitle?: string,
     locationId: string,
+    contentPadding?: boolean,
   },
 }


### PR DESCRIPTION
This PR is a SDK part of passing `contentPadding` prop into component section component. I have provided a [PR](https://github.com/shopware/platform/pull/3021) for implementing the new prop in Shopware Core.