### PR TITLE
fix: update node version to 18

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/gallium'
+          node-version: '18'
 
       - name: Retrieve the cached main "node_modules" directory (if present)
         uses: actions/cache@v2

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/gallium'
+          node-version: '18'
       - name: Retrieve the cached "node_modules" directory (if present)
         uses: actions/cache@v3
         id: node-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/gallium'
+          node-version: '18'
       - name: Retrieve the cached "node_modules" directory (if present)
         uses: actions/cache@v2
         id: node-cache
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/gallium'
+          node-version: '18'
       - name: Retrieve the cached "node_modules" directory (if present)
         uses: actions/cache@v2
         id: node-cache


### PR DESCRIPTION
npm provenance is only available with npm 9.5