### PR TITLE
NEXT-25821 - add documentation about using the same domain

### DIFF
--- a/docs/docs/guide/6_faq/_category_.yml
+++ b/docs/docs/guide/6_faq/_category_.yml
@@ -1,0 +1,2 @@
+label: "FAQ"
+position: 1100

--- a/docs/docs/guide/6_faq/index.md
+++ b/docs/docs/guide/6_faq/index.md
@@ -1,0 +1,9 @@
+---
+title: "FAQ"
+---
+
+# FAQ
+
+## Can I use the same domain with subfolders for multiple apps?
+No, for technical reasons, it is not possible to use the same domain with subfolders to host multiple apps. Each app must have its own separate domain.
+The preferred solution is to use subdomains for each app. For example, you can use subdomains like "app-one.your-company.com", "app-two.your-company.com", and so on. Using subdomains allows you to have separate domains for each app, which avoids the technical limitations associated with using subfolders.


### PR DESCRIPTION
We tried several things to make the same domain working with multiple subfolders for different apps. Unfortunately this is not solvable due to the nature of iFrames and PostMessage security. So I added a short FAQ entry where it explains that is not possible and that the preferred way would be subdomains.