### PR TITLE
NTR - Add package.json import paths for admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,24 @@
   "main": "./umd/index.js",
   "module": "./es/index.js",
   "exports": {
+    "./es/location": {
+      "import": "./es/location/index.js"
+    },
+    "./es/data/Criteria": {
+      "import": "./es/data/Criteria.js"
+    },
+    "./es/channel": {
+      "import": "./es/channel.js"
+    },
+    "./es/data/_internals/Entity": {
+      "import": "./es/data/_internals/Entity.js"
+    },
+    "./es/data/_internals/EntityCollection": {
+      "import": "./es/data/_internals/EntityCollection.js"
+    },
+    "./es/data": {
+      "import": "./es/data/index.js"
+    },
     ".": {
       "import": "./es/index.js",
       "require": "./umd/index.js"


### PR DESCRIPTION
This PR fixes building the administration with vite. Vite complains about every import that doesn't have a corresponding export in the `exports` field, if such a configuration exists.

![Vite error because export is not defined](https://github.com/shopware/admin-extension-sdk/assets/31859769/cf482f83-9a63-4e0f-acb9-26eba91c4558)

This solution is certainly not perfect, but it makes vite happy. Ideally we would consolidate our imports in the admin as the node docs recommend, or we should put targeted sub exports in our package.json and those then would be exclusively used.

How to test:

Try to start the watch mode of my vite PoC or search for all imports in the administration and try to find a corresponding entry in the package.json config