### PR TITLE
NEXT-28963 - Fix data handling types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-ag/admin-extension-sdk",
   "license": "MIT",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "repository": "git://github.com/shopware/admin-extension-sdk.git",
   "description": "The SDK for App iframes to communicate with the Shopware Administration",
   "keywords": [

--- a/src/_internals/serializer/criteria-serializer.ts
+++ b/src/_internals/serializer/criteria-serializer.ts
@@ -40,7 +40,6 @@ const CriteriaSerializer: SerializerFactory = () => ({
         // @ts-expect-error
         serializedData.associations.forEach((association) => {
           // Associations need also to be deserialized
-          // @ts-expect-error
           deserializedCriteria.associations.push(customizerMethod(association));
         });
         // @ts-expect-error

--- a/src/data/Criteria.ts
+++ b/src/data/Criteria.ts
@@ -169,35 +169,35 @@ export function setDefaultValues(options: { page?: number|null, limit?: number|n
 }
 
 export default class Criteria {
-  private page: number | null;
+  page: number | null;
 
-  private limit: number | null;
+  limit: number | null;
 
-  private term: string | null;
+  term: string | null;
 
-  private filters: SingleFilter[];
+  filters: SingleFilter[];
 
-  private ids: string[];
+  ids: string[];
 
-  private queries: Query[];
+  queries: Query[];
 
-  private associations: Association[];
+  associations: Association[];
 
-  private postFilter: SingleFilter[];
+  postFilter: SingleFilter[];
 
-  private sortings: Sorting[];
+  sortings: Sorting[];
 
-  private aggregations: Aggregation[];
+  aggregations: Aggregation[];
 
-  private grouping: string[];
+  grouping: string[];
 
-  private fields: string[];
+  fields: string[];
 
-  private groupFields: GroupField[];
+  groupFields: GroupField[];
 
-  private totalCountMode: TotalCountMode | null;
+  totalCountMode: TotalCountMode | null;
 
-  private includes: Include | null;
+  includes: Include | null;
 
   constructor(page: number|null = defaultPage, limit: number|null = defaultLimit) {
     this.page = page;


### PR DESCRIPTION
### Description

Vue 3 has a problem with anything but plain objects being used as reactive values.
Our current data handling solution uses custom proxies for nearly anything. Each entity is a custom proxy object, which Vue 3 highly misadvises to use. We need to discuss possible solutions. 

### Solution

Remove the `private` annotation on fields of the criteria class. This is unproblematic, as TypeScript didn't enforce the `private` declaration and fields could have been accessed and modified before.
