### PR TITLE
Change code example to have two distinct variable names

### DIFF
--- a/docs/docs/guide/2_api-reference/data/get.md
+++ b/docs/docs/guide/2_api-reference/data/get.md
@@ -11,8 +11,8 @@ such as when opening a page, you won't receive any data. In these cases, it's be
 data.get({
     id: 'sw-product-detail__product',
     selectors: ['name', 'manufacturer.name'],
-}).then((data) => {
-    console.log(data);
+}).then((product) => {
+    console.log(product);
 });
 ```
 


### PR DESCRIPTION
The previous code was not easy to copy-paste-trial-error because it introduces a new variable called `data` that is already used to provide the data accessing methods. This just breaks samples one tries to copy and paste together. I saw this at multiple spots in your samples. Maybe you want to discuss, whether this finding should be applied all over the docs or not.